### PR TITLE
[week03] BOJ 9252 LCS2(골드5) / BOJ 5582 공통부분문자열(골드5) / BOJ 5557 1학년(골드5)

### DIFF
--- a/week03/yj-leez/B5557.java
+++ b/week03/yj-leez/B5557.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class B5557 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] nums = new int[n];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            nums[i] = Integer.parseInt(st.nextToken());
+        }
+
+        long[][] sum = new long[n - 1][21];
+
+        sum[0][nums[0]] = 1;
+        for (int i = 1; i < n - 1; i++) {
+            for (int j = 0; j <= 20; j++) {
+                if (sum[i - 1][j] > 0){
+                    int plus = j + nums[i];
+                    int minus = j - nums[i];
+
+                    if (0 <= plus && plus <= 20){
+                        sum[i][plus] += sum[i - 1][j];
+                    }
+
+                    if (0 <= minus && minus <= 20){
+                        sum[i][minus] += sum[i - 1][j];
+                    }
+                }
+
+            }
+        }
+
+        System.out.println(sum[n - 2][nums[n - 1]]);
+
+    }
+}

--- a/week03/yj-leez/B5582.java
+++ b/week03/yj-leez/B5582.java
@@ -1,0 +1,25 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class B5582 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] str1 = br.readLine().split("");
+        String[] str2  = br.readLine().split("");
+
+        int[][] dp = new int[str1.length + 1][str2.length + 1];
+        int ans = 0;
+        for (int i = 1; i <= str1.length; i++) {
+            for (int j = 1; j <= str2.length; j++) {
+                if (str1[i - 1].equals(str2[j - 1])){
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                    ans = Math.max(ans, dp[i][j]);
+                }
+            }
+        }
+
+        System.out.println(ans);
+
+    }
+}

--- a/week03/yj-leez/B9252.java
+++ b/week03/yj-leez/B9252.java
@@ -1,0 +1,53 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class B9252 {
+
+    static int[][] dp;
+    static String[] str1;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        str1 = br.readLine().split("");
+        String[] str2 = br.readLine().split("");
+
+        dp = new int[str1.length + 1][str2.length + 1];
+        for (int i = 1; i <= str1.length; i++) {
+            for (int j = 1; j <= str2.length; j++) {
+                if (str1[i - 1].equals(str2[j - 1])){
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                } else {
+                    dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+                }
+            }
+        }
+
+        System.out.println(dp[str1.length][str2.length]);
+        LCS(str1.length, str2.length);
+    }
+
+    static void LCS(int i, int j){
+        Stack<String> stack = new Stack<>();
+
+        while (i > 0 && j > 0) {
+            if (dp[i][j] == dp[i - 1][j]){
+                i--;
+            } else if (dp[i][j] == dp[i][j - 1]){
+                j--;
+            } else {
+                stack.push(str1[i - 1]);
+                i--;
+                j--;
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        while(!stack.empty()){
+            sb.append(stack.pop());
+        }
+
+        System.out.println(sb);
+
+    }
+}


### PR DESCRIPTION
# LCS2
### 🤔 접근 방법 (문제 풀이법)
- 알고리즘: dp, LCS
- LCS1의 LCS의 길이를 똑같이 구하되, 이차원배열의 제일 오른쪽 하단에서부터 아래의 조건을 만족하는 문자들을 Stack에 넣은 후, 왼쪽 상단까지 도달했을 때 Stack을 pop하여 LCS 문자열을 구하는 로직을 추가하였다.
  - 바로 옆과 위의 문자와 일치하지 않는 경우, 왼쪽 상단 대각선으로 이동하고 Stacke에 추가한다.
  - 즉, 공통 부분을 찾은 로직의 정반대로 이동한다.
<br/><br/>
### ❓ 실패 이유
- 
<br/><br/>
### ⌛ 예상 시간 복잡도
- str1문자열의 길이 * str2 문자열의 길이 + stack에 넣는 시간

# 공통부분문자열
### 🤔 접근 방법 (문제 풀이법)
- 알고리즘: dp
- LCS와 비슷한 로직이지만, 중간에 일치하지 않은 문자가 들어가면 공통부분문자열로 치지않으므로 Math.max(위의 값, 왼쪽의 값)이 아닌 0을 저장한다.
```java
if (str1[i - 1].equals(str2[j - 1])){
     dp[i][j] = dp[i - 1][j - 1] + 1;
     ans = Math.max(ans, dp[i][j]);
}
```
<br/><br/>
### ❓ 실패 이유
- 
<br/><br/>
### ⌛ 예상 시간 복잡도
- str1문자열의 길이 * str2 문자열의 길이

# 1학년
### 🤔 접근 방법 (문제 풀이법)
- 알고리즘: dp
- 숫자의 범위가 정해져있으므로 각 단계별로 나올 수 있는 값의 경우의 수를 이차원 배열로 저장한다. 그 다음 열에서 전의 열을 활용한다.
<br/><br/>
### ❓ 실패 이유
- 범위 확인을 하지 않아 int형으로 했을 때 잘못된 값이 나왔다. int -> long형으로 수정하였다.
<br/><br/>
### ⌛ 예상 시간 복잡도
- 21 * (n - 2)